### PR TITLE
Document proc settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,13 @@ sysctl -w kernel.msgmnb=2000000
 or write to /etc/sysctl.conf:
 
 ```sh
-echo 'kernel.msgmni=32' >> /etc/sysctl.conf
-echo 'kernel.msgmax=1000000' >> /etc/sysctl.conf
-echo 'kernel.msgmnb=2000000' >> /etc/sysctl.conf
+echo 'kernel.msgmni=32' >> /etc/sysctl.conf # maximum number of message queues
+echo 'kernel.msgmax=1000000' >> /etc/sysctl.conf # maximum number of bytes per message
+echo 'kernel.msgmnb=2000000' >> /etc/sysctl.conf # maximum total size of all messages in a queue
 sysctl -p
 ```
+
+See http://man7.org/linux/man-pages/man5/proc.5.html for more information.
 
 ## Todo
 


### PR DESCRIPTION
Hi there...

I've been using this in development for a while and it's working great. I'm planning on putting it into production shortly.

I thought it would be a good idea to document the various settings that control SysV queues. It took me a while to figure out what was going wrong since the error messages are a bit cryptic:

```
Invalid argument - Failed sending message to queue (Errno::EINVAL)
```

I'm sure you know all about them, but here are the relevant settings:

```
msgmni: The number of IPC message queue resources allowed (by default, 16).
msgmnb: The size of each message (by default, 8,192 bytes).
msgmax: The maximum total size of the messages in a queue (by default, 16,384 byte...
```

Stolen from https://access.redhat.com/site/articles/15423 .
