### PR TITLE
sysv: fix segfault on non strings by always calling to_s

### DIFF
--- a/ext/sysvmq.c
+++ b/ext/sysvmq.c
@@ -282,6 +282,8 @@ sysvmq_send(int argc, VALUE *argv, VALUE self)
   if (argc >= 2) priority = argv[1];
   if (argc == 3) flags    = argv[2];
 
+  message = rb_funcall(message, rb_intern("to_s"), 0);
+
   TypedData_Get_Struct(self, sysvmq_t, &sysvmq_type, sysv);
 
   Check_Type(flags,    T_FIXNUM);

--- a/test/sysv_mq_test.rb
+++ b/test/sysv_mq_test.rb
@@ -130,4 +130,18 @@ class SysVMQTest < MiniTest::Unit::TestCase
     @mq.send(message)
     assert_equal message, @mq.receive
   end
+
+  def test_number_converted_to_string
+    message = 1
+    @mq.send(message)
+    assert_equal "1", @mq.receive
+  end
+
+  class Walrus; def to_s; "walrus"; end; end
+
+  def test_object_converted_to_string
+    message = Walrus.new
+    @mq.send(message)
+    assert_equal "walrus", @mq.receive
+  end
 end


### PR DESCRIPTION
@alexdean fixes #10  by always calling `#to_s`. Looks good to you? Then I'll merge and release a new gem.
