### PR TITLE
Fix FIX2LONG addition

### DIFF
--- a/ext/sysvmq.c
+++ b/ext/sysvmq.c
@@ -359,7 +359,7 @@ sysvmq_initialize(VALUE self, VALUE key, VALUE buffer_size, VALUE flags)
   // for each message sent. This makes SysVMQ not thread-safe (requiring a
   // buffer for each thread), but is a reasonable trade-off for now for the
   // performance.
-  sysv->buffer_size = (size_t) FIX2LONG(buffer_size + 1);
+  sysv->buffer_size = (size_t) FIX2LONG(buffer_size) + 1;
   msgbuf_size = sysv->buffer_size * sizeof(char) + sizeof(long);
 
   // Note that this is a zero-length array, so we size the struct to size of the


### PR DESCRIPTION
We cannot add to buffer_size because it is a Ruby VALUE object. By adding one to buffer_size we turn it from a fixnum into something else because fixnums use the bottom bit to determine that is a fixnum. Instead, we should be incrementing the value after the FIX2LONG.